### PR TITLE
Fix for passing args without `Copy`

### DIFF
--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -272,7 +272,7 @@ fn generate_body(
         #(
             #save_position
             #field_asserts
-            let #name_args = #passed_args_closure;
+            let #name_args = (#passed_args_closure).clone();
             let #name_options = #new_options;
             
             #setup_possible_if
@@ -286,11 +286,11 @@ fn generate_body(
                         #after_parse_applier(
                             #possible_immediate_derefs,
                             #maps(#possible_try_conversion(#repeat_read_method_ident(
-                                #repeat_reader_ident, #name_options, #name_args
+                                #repeat_reader_ident, #name_options, (#name_args).clone()
                             ))#repeat_handle_error?),
                             #repeat_reader_ident,
                             #name_options,
-                            #name_args,
+                            #name_args.clone(),
                         )?
                     );
 
@@ -315,7 +315,7 @@ fn generate_body(
                     #possible_mut #name,
                     #repeat_reader_ident,
                     #name_options,
-                    #name_args,
+                    (#name_args).clone(),
                 )#repeat_handle_error2?
             };
         )*
@@ -390,7 +390,7 @@ fn get_name_modified(idents: &[Ident], append: &str) -> Vec<Ident> {
     idents
         .into_iter()
         .map(|ident|{
-            format_ident!("__{}_binwrite_generated_{}", ident.to_string(), append)
+            format_ident!("__{}_binread_generated_{}", ident.to_string(), append)
         })
         .collect()
 }


### PR DESCRIPTION
Per the name