### PR TITLE
Implement pre-assert

### DIFF
--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -16,7 +16,8 @@ use syn::ExprClosure;
 use syn::punctuated::Punctuated;
 use proc_macro2::TokenStream as TokenStream2;
 
-// import, return_all_errors, return_unexpected_error, little, big, assert, magic
+// import, return_all_errors, return_unexpected_error, little, big, assert,
+// magic, pre_assert
 parse_any!{
     enum TopLevelAttr {
         // bool type
@@ -31,6 +32,7 @@ parse_any!{
         // args type
         Import(MetaList<kw::import, ImportArg>),
         Assert(MetaList<kw::assert, Expr>),
+        PreAssert(MetaList<kw::pre_assert, Expr>),
     }
 }
 

--- a/src/meta_attrs/parser/keywords.rs
+++ b/src/meta_attrs/parser/keywords.rs
@@ -16,6 +16,7 @@ kws!{
     little,     // little
     magic,      // magic = [lit]
     assert,     // assert(expr)
+    pre_assert,     // pre_assert(expr)
 
     // top-level
     import,     // import(expr, ..)

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -25,6 +25,7 @@ pub struct TopLevelAttrs {
     // assertions/error handling
     pub assert: Vec<Assert>,
     pub magic: Option<TokenStream>,
+    pub pre_assert: Vec<Assert>,
 }
 
 macro_rules! get_tla_type {
@@ -94,7 +95,8 @@ impl TopLevelAttrs {
         let magics = get_tla_type!(attrs.Magic);
         let imports = get_tla_type!(attrs.Import);
         let asserts = get_tla_type!(attrs.Assert);
-        
+        let pre_asserts = get_tla_type!(attrs.PreAssert);
+
         let magic = get_only_first(&magics, "Cannot define multiple magic values")?;
         let import = get_only_first(&imports, "Cannot define multiple sets of arguments")?;
 
@@ -105,7 +107,8 @@ impl TopLevelAttrs {
             magic: magic.map(magic_to_tokens),
             import: import.map(convert_import).unwrap_or_default(),
             return_all_errors: first_span_true(return_all_errors),
-            return_unexpected_error: first_span_true(return_unexpected_errors)
+            return_unexpected_error: first_span_true(return_unexpected_errors),
+            pre_assert: pre_asserts.into_iter().map(convert_assert).collect::<Result<_, _>>()?,
         })
     }
 }


### PR DESCRIPTION
Adds a new `#[br(pre_assert)]` attribute that may be used to choose an enum variant to parse (similar to magic) based on arguments.