### PR TITLE
Implement args_tuple and import_tuple

### DIFF
--- a/src/codegen/arg_type.rs
+++ b/src/codegen/arg_type.rs
@@ -5,10 +5,6 @@ use quote::quote;
 
 /// Generate the argument type for the derived impl
 pub fn generate(tla: &TopLevelAttrs) -> Result<TokenStream, CompileError> {
-    let types: Vec<_> = tla.import.types().collect();
-
-    Ok(quote!{
-        (#(#types,)*)
-    })
+    Ok(tla.import.types())
 }
 

--- a/src/meta_attrs/mod.rs
+++ b/src/meta_attrs/mod.rs
@@ -11,6 +11,7 @@ use crate::compiler_error::SpanError;
 use syn::{Ident, Lit, NestedMeta, Path, Type, Field, Meta, Expr, spanned::Spanned};
 use quote::ToTokens;
 use std::str::FromStr;
+use syn::export::TokenStream2;
 
 #[derive(Debug, Clone)]
 pub struct Assert(pub TokenStream, pub Option<TokenStream>);
@@ -21,22 +22,70 @@ struct MultiformExpr(TokenStream);
 #[derive(Debug, Default, Clone)]
 pub struct PassedValues(Vec<TokenStream>);
 
+#[derive(Debug, Clone)]
+pub enum PassedArgs {
+    List(PassedValues),
+    Tuple(TokenStream)
+}
+
+impl Default for PassedArgs {
+    fn default() -> Self {
+        PassedArgs::List(PassedValues::default())
+    }
+}
+
 impl PassedValues {
     pub fn iter(&self) -> impl Iterator<Item = &TokenStream> {
         self.0.iter()
     }
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct Imports(pub Vec<Ident>, pub Vec<Type>);
+#[derive(Debug, Clone)]
+pub enum Imports {
+    List(Vec<Ident>, Vec<Type>),
+    Tuple(Ident, Type)
+}
+
+impl Default for Imports {
+    fn default() -> Self {
+        Imports::List(Vec::new(), Vec::new())
+    }
+}
 
 impl Imports {
-    pub fn idents<'a>(&'a self) -> impl Iterator<Item=&'a Ident> {
-        self.0.iter()
+    pub fn idents(&self) -> TokenStream2 {
+        match self {
+            Imports::List(idents, _) => {
+                let idents = idents.iter();
+                quote::quote! {
+                    (#(mut #idents,)*)
+                }
+            },
+            Imports::Tuple(ident, _) => quote::quote! {
+                mut #ident
+            }
+        }
     }
-    
-    pub fn types<'a>(&'a self) -> impl Iterator<Item=&'a Type> {
-        self.1.iter()
+
+    pub fn types(&self) -> TokenStream2 {
+        match self {
+            Imports::List(_, types) => {
+                let types = types.iter();
+                quote::quote! {
+                    (#(#types,)*)
+                }
+            },
+            Imports::Tuple(_, ty) => {
+                ty.to_token_stream()
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Imports::List(idents, _) => idents.is_empty(),
+            Imports::Tuple(_, _) => false
+        }
     }
 }
 

--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -15,6 +15,7 @@ use syn::{parenthesized, parse_macro_input, token, Field, Ident, Token, Lit, Pat
 use syn::ExprClosure;
 use syn::punctuated::Punctuated;
 use proc_macro2::TokenStream as TokenStream2;
+use quote::ToTokens;
 
 // import, return_all_errors, return_unexpected_error, little, big, assert,
 // magic, pre_assert
@@ -31,6 +32,7 @@ parse_any!{
 
         // args type
         Import(MetaList<kw::import, ImportArg>),
+        ImportTuple(ImportArgTuple),
         Assert(MetaList<kw::assert, Expr>),
         PreAssert(MetaList<kw::pre_assert, Expr>),
     }
@@ -63,6 +65,7 @@ parse_any!{
 
         // args type
         Args(MetaList<kw::args, Expr>),
+        ArgsTuple(MetaExpr<kw::args_tuple>),
         Assert(MetaList<kw::assert, Expr>),
 
         // expr type
@@ -105,6 +108,30 @@ impl Parse for ImportArg {
             colon: input.parse()?,
             ty: input.parse()?
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportArgTuple {
+    pub ident: kw::import_tuple,
+    pub parens: token::Paren,
+    pub arg: ImportArg
+}
+
+impl Parse for ImportArgTuple {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(ImportArgTuple {
+            ident: input.parse()?,
+            parens: parenthesized!(content in input),
+            arg: content.parse()?
+        })
+    }
+}
+
+impl ToTokens for ImportArgTuple {
+    fn to_tokens(&self, _tokens: &mut TokenStream2) {
+        //self.arg.to_tokens(tokens) // TODO? I notice that MetaList doesn't do anything in its implementation
     }
 }
 

--- a/src/meta_attrs/parser/keywords.rs
+++ b/src/meta_attrs/parser/keywords.rs
@@ -20,6 +20,7 @@ kws!{
 
     // top-level
     import,     // import(expr, ..)
+    import_tuple, // import(expr)
     return_all_errors,
     return_unexpected_error,
 
@@ -31,6 +32,7 @@ kws!{
     is_little,  // is_little = [expr]
     is_big,     // is_big = [expr]
     args,       // args(expr, ..)
+    args_tuple, // args_tuple = [expr]
     default,    // default
     ignore,     // ignore
     deref_now,  // deref_now

--- a/src/meta_attrs/parser/parsing_tests.rs
+++ b/src/meta_attrs/parser/parsing_tests.rs
@@ -55,6 +55,7 @@ test_tla!(parse_big, "big");
 test_tla!(parse_magic, "magic = 3u8");
 test_tla!(parse_magic_paren, "magic(2u16)");
 test_tla!(parse_import, "import(x: u32, y: &[f32])");
+test_tla!(parse_import_tuple, "import_tuple(args: (u32))");
 
 test_fla!(fla_little, "little");
 test_fla!(fla_magic, "magic = b\"TEST\"");
@@ -69,6 +70,7 @@ test_fla!(fla_assert, "assert(
 )");
 test_fla!(fla_count, "count = extra_entry_count + 1");
 test_fla!(fla_args, "args(x, (y, z), 3 + 4)");
+test_fla!(fla_args_tuple, "args_tuple = x");
 test_fla!(fla_default, "default");
 test_fla!(fla_try, "try");
 test_fla!(fla_offset, "offset = 3 + x");


### PR DESCRIPTION
May want to bikeshed the attribute names a bit, `args_raw` and `import_raw` might be a bit better?

Frankly, I'm not familiar enough with proc macros to be comfortable with merging this immediately. It seems to work okay, at least, but I don't know what I may have missed.

Progress towards jam1garner/binread#13 . Will need to add documentation to binread proper at the very least before that issue can be closed.