### PR TITLE
Code clean-ups

### DIFF
--- a/src/codegen/arg_type.rs
+++ b/src/codegen/arg_type.rs
@@ -1,7 +1,6 @@
 use proc_macro2::TokenStream;
 use super::TopLevelAttrs;
 use crate::CompileError;
-use quote::quote;
 
 /// Generate the argument type for the derived impl
 pub fn generate(tla: &TopLevelAttrs) -> Result<TokenStream, CompileError> {

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -482,7 +482,7 @@ fn get_struct_names_types(input: &DataStruct) -> (Vec<Ident>, Vec<&Type>, Struct
 
 fn get_name_modified(idents: &[Ident], append: &str) -> Vec<Ident> {
     idents
-        .into_iter()
+        .iter()
         .map(|ident|{
             format_ident!("__{}_binread_generated_{}", ident.to_string(), append)
         })
@@ -510,7 +510,7 @@ fn get_struct_field_attrs(input: &DataStruct) -> Result<Vec<FieldLevelAttrs>, Co
 
 fn get_passed_args(field_attrs: &[FieldLevelAttrs]) -> Vec<TokenStream> {
     field_attrs
-        .into_iter()
+        .iter()
         .map(|field_attr| {
             match &field_attr.args {
                 PassedArgs::List(list) => {
@@ -609,7 +609,7 @@ fn get_modified_options<'a, I: IntoIterator<Item = (IdentStr<'a>, TokenStream)>>
 
 fn get_new_options(idents: &[Ident], field_attrs: &[FieldLevelAttrs]) -> Vec<TokenStream> {
     field_attrs
-        .into_iter()
+        .iter()
         .zip(idents)
         .map(|(a, b)| get_modified_options(get_name_option_pairs_ident_expr(a, b)))
         .collect()
@@ -671,7 +671,7 @@ fn get_assertions(asserts: &[Assert]) -> Vec<TokenStream> {
 fn get_field_assertions(field_attrs: &[FieldLevelAttrs]) -> Vec<TokenStream> {
     let handle_error = handle_error();
     field_attrs
-        .into_iter()
+        .iter()
         .map(|field_attrs|{
             let asserts = field_attrs.assert
                 .iter()

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -273,7 +273,7 @@ fn generate_struct(input: &DeriveInput, tla: &TopLevelAttrs, ds: &DataStruct) ->
 
 #[allow(unused_variables)]
 fn generate_body(
-        tla: &TopLevelAttrs, field_attrs: &[FieldLevelAttrs], name: &Vec<Ident>, ty: Vec<&Type>
+        tla: &TopLevelAttrs, field_attrs: &[FieldLevelAttrs], name: &[Ident], ty: Vec<&Type>
     ) -> Result<TokenStream, CompileError>
 {
     let count = name.len();

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use proc_macro2::TokenStream;
 use quote::{quote, format_ident, ToTokens};
-use syn::{Ident, DeriveInput, Type, DataStruct, DataEnum, Expr, Field, Fields, Variant, punctuated::Punctuated, token::Comma};
+use syn::{Ident, DeriveInput, Type, DataStruct, DataEnum, Field, Fields, Variant, punctuated::Punctuated, token::Comma};
 
 pub fn generate(input: &DeriveInput, tla: &TopLevelAttrs) -> Result<TokenStream, CompileError> {
     if let Some(map) = &tla.map {

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -271,7 +271,6 @@ fn generate_struct(input: &DeriveInput, tla: &TopLevelAttrs, ds: &DataStruct) ->
     })
 }
 
-#[allow(unused_variables)]
 fn generate_body(
         tla: &TopLevelAttrs, field_attrs: &[FieldLevelAttrs], name: &[Ident], ty: Vec<&Type>
     ) -> Result<TokenStream, CompileError>
@@ -285,10 +284,10 @@ fn generate_body(
 
     // Repeat constants
     let repeat_read_method_ident = filter_by_ignore(&field_attrs, iter::repeat(READ_METHOD));
-    let repeat_options_ident = iter::repeat(OPTIONS);
+    let _repeat_options_ident = iter::repeat(OPTIONS);
     let repeat_reader_ident = iter::repeat(READER).take(count).collect::<Vec<_>>();
-    let repeat_opt_ident = iter::repeat(OPT);
-    let default = iter::repeat(DEFAULT);
+    let _repeat_opt_ident = iter::repeat(OPT);
+    let _default = iter::repeat(DEFAULT);
 
     let possible_set_offset = get_possible_set_offset(&field_attrs, &name_options);
 

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -30,11 +30,7 @@ pub fn generate(input: &DeriveInput, tla: &TopLevelAttrs) -> Result<TokenStream,
 }
 
 fn no_variant_data(v: &Variant) -> bool {
-    if let Fields::Unit = v.fields {
-        true
-    } else {
-        false
-    }
+    matches!(v.fields, Fields::Unit)
 }
 
 fn magic_type_of(variant: &Variant) -> Option<(MagicType, TokenStream)> {

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -95,7 +95,7 @@ fn generate_enum(input: &DeriveInput, tla: &TopLevelAttrs, en: &DataEnum) -> Res
     }
 
     // return_all_errors is default behavior
-    let return_all_errors = *tla.return_all_errors || !*tla.return_all_errors;
+    let return_all_errors = !*tla.return_unexpected_error;
 
     let enum_name = &input.ident;
     let variant_funcs =

--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -348,7 +348,7 @@ fn generate_body(
                     #skip_before
                     #align_before
                     #pad_size_to_prep
-                    let __binread__temp = #possible_some(
+                    let __binread_temp = #possible_some(
                         #after_parse_applier(
                             #possible_immediate_derefs,
                             #maps(#possible_try_conversion(#repeat_read_method_ident(
@@ -364,7 +364,7 @@ fn generate_body(
                     #skip_after
                     #align_after
 
-                    __binread__temp
+                    __binread_temp
                 } #possible_else;
             #field_asserts
             #restore_position

--- a/src/codegen/sanitization.rs
+++ b/src/codegen/sanitization.rs
@@ -1,4 +1,3 @@
-#![allow(non_upper_case_globals)]
 ///! Utilities for helping sanitize macro
 use proc_macro2::{TokenStream, Ident};
 use quote::{quote, format_ident, ToTokens};

--- a/src/codegen/sanitization.rs
+++ b/src/codegen/sanitization.rs
@@ -53,7 +53,7 @@ pub static AFTER_PARSE_TRY: IdentStr = from_crate!(error::try_after_parse);
 pub static AFTER_PARSE_IDENTITY: IdentStr = from_crate!(error::identity_after_parse);
 pub static TRY_CONVERSION: IdentStr = from_crate!(error::try_conversion);
 
-pub static TEMP: IdentStr = IdentStr("__binread__temp");
+pub static TEMP: IdentStr = IdentStr("__binread_temp");
 pub static POS: IdentStr = IdentStr("__binread_generated_position_temp");
 
 

--- a/src/codegen/sanitization.rs
+++ b/src/codegen/sanitization.rs
@@ -1,13 +1,9 @@
-#![allow(dead_code, non_upper_case_globals)]
+#![allow(non_upper_case_globals)]
 ///! Utilities for helping sanitize macro
 use proc_macro2::{TokenStream, Ident};
 use quote::{quote, format_ident, ToTokens};
 
-const CNAME: &str = "::binread";
-const TNAME: &str = "BinRead";
-
 macro_rules! from_crate {
-    () => { IdentStr(CNAME) };
     ($path:path) => { IdentStr(concat!("::binread::", stringify!($path))) };
 }
 
@@ -16,7 +12,6 @@ macro_rules! from_trait {
     ($path:path) => { IdentStr(concat!("::binread::BinRead::", stringify!($path))) };
 }
 
-pub static CRATE_NAME: IdentStr = from_crate!();
 pub static TRAIT_NAME: IdentStr = from_trait!();
 
 pub static BIN_ERROR: IdentStr = from_crate!(Error);
@@ -33,19 +28,16 @@ pub static AFTER_PARSE: IdentStr = from_trait!(after_parse);
 pub static READER: IdentStr = IdentStr("__binread_generated_var_reader");
 pub static OPT: IdentStr = IdentStr("__binread_generated_var_options");
 pub static ARGS: IdentStr = IdentStr("__binread_generated_var_arguments");
-pub static AFTER_OPTS: IdentStr = IdentStr("__binread_generated_var_after_options"); 
 
 pub static DEFAULT: IdentStr = IdentStr("core::default::Default::default");
 
 pub static ASSERT_MAGIC: IdentStr = from_crate!(error::magic);
-//pub static ASSERT_EQ: IdentStr = from_crate!(error::assert_eq);
 pub static ASSERT: IdentStr = from_crate!(error::assert);
 
 pub static WRITE_START_STRUCT: IdentStr = from_crate!(binary_template::write_start_struct);
 pub static WRITE_END_STRUCT: IdentStr = from_crate!(binary_template::write_end_struct);
 pub static WRITE_COMMENT: IdentStr = from_crate!(binary_template::write_comment);
 
-pub static IDENTITY_FN: IdentStr = IdentStr("core::convert::identity");
 pub static READ_METHOD_NOP: IdentStr = from_crate!(error::nop3);
 pub static READ_METHOD_DEFAULT: IdentStr = from_crate!(error::nop3_default);
 pub static AFTER_PARSE_NOP: IdentStr = from_crate!(error::nop5);
@@ -61,10 +53,6 @@ pub fn closure_wrap<T: ToTokens>(value: T) -> TokenStream {
     quote!(
         (||{ #value })()
     )
-}
-
-pub fn fmt_ident_options<S: ToString>(ident: S) -> Ident {
-    format_ident!("__{}_options", ident.to_string())
 }
 
 /// A string wrapper that converts the str to a $path TokenStream, allowing for constant-time

--- a/src/codegen/sanitization.rs
+++ b/src/codegen/sanitization.rs
@@ -1,5 +1,5 @@
 ///! Utilities for helping sanitize macro
-use proc_macro2::{TokenStream, Ident};
+use proc_macro2::TokenStream;
 use quote::{quote, format_ident, ToTokens};
 
 macro_rules! from_crate {

--- a/src/compiler_error.rs
+++ b/src/compiler_error.rs
@@ -10,7 +10,6 @@ pub enum CompileError {
 pub struct SpanError(pub Span, pub String);
 
 impl SpanError {
-    #[allow(dead_code)]
     pub fn new<E: Into<String>>(span: Span, err: E) -> Self {
         SpanError(span, err.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused_imports, unused_macros)]
+#![allow(unused_imports)]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
-#![allow(unused_imports)]
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use quote::{quote, quote_spanned, format_ident, ToTokens};
+use quote::{quote, quote_spanned};
 use syn::{
-    spanned::Spanned,
     parse_macro_input,
     DeriveInput
 };
@@ -16,7 +14,7 @@ mod compiler_error;
 
 use codegen::sanitization::*;
 use meta_attrs::FieldLevelAttrs;
-use proc_macro2::{TokenStream as TokenStream2, Span};
+use proc_macro2::TokenStream as TokenStream2;
 use compiler_error::{CompileError, SpanError};
 
 fn generate_derive(input: DeriveInput, code: codegen::GeneratedCode) -> TokenStream {

--- a/src/meta_attrs/field_level_attrs.rs
+++ b/src/meta_attrs/field_level_attrs.rs
@@ -187,7 +187,7 @@ impl FieldLevelAttrs {
     }
 }
 
-fn get_only_first<'a, S: Spanned>(list: &'a Vec<S>, msg: &str) -> Result<Option<&'a S>, CompileError> {
+fn get_only_first<'a, S: Spanned>(list: &'a [S], msg: &str) -> Result<Option<&'a S>, CompileError> {
     if list.len() > 1 {
         let mut spans = list.iter().map(Spanned::span);
 

--- a/src/meta_attrs/field_level_attrs.rs
+++ b/src/meta_attrs/field_level_attrs.rs
@@ -116,7 +116,7 @@ impl FieldLevelAttrs {
         let pad_size_to = get_fla_type!(attrs.PadSizeTo);
 
         // TODO: This is basically get_only_first but for mutually incompatible attributes. refactor?
-        if args.len() > 0 && args_tuple.len() > 0 {
+        if !args.is_empty() && !args_tuple.is_empty() {
             let mut spans = args.iter()
                 .map(Spanned::span)
                 .chain(args_tuple.iter().map(Spanned::span));

--- a/src/meta_attrs/field_level_attrs.rs
+++ b/src/meta_attrs/field_level_attrs.rs
@@ -72,8 +72,7 @@ impl FieldLevelAttrs {
                 .map(flas_from_attribute)
                 .collect::<Result<Vec<FlaList>, CompileError>>()?
                 .into_iter()
-                .map(|x| x.0.into_iter())
-                .flatten()
+                .flat_map(|x| x.0.into_iter())
                 .collect();
 
         // bool type

--- a/src/meta_attrs/field_level_attrs.rs
+++ b/src/meta_attrs/field_level_attrs.rs
@@ -113,20 +113,7 @@ impl FieldLevelAttrs {
         let seek_before = get_fla_type!(attrs.SeekBefore);
         let pad_size_to = get_fla_type!(attrs.PadSizeTo);
 
-        // TODO: This is basically get_only_first but for mutually incompatible attributes. refactor?
-        if args.clone().next().is_some() && args_tuple.clone().next().is_some() {
-            let mut spans = args
-                .map(Spanned::span)
-                .chain(args_tuple.map(Spanned::span));
-
-            let first = spans.next().unwrap();
-            let span = spans.fold(first, |x, y| x.join(y).unwrap());
-
-            return Err(CompileError::SpanError(SpanError::new(
-                span,
-                "Conflicting instances of args and args_tuple"
-            )));
-        }
+        check_mutually_exclusive(args.clone(), args_tuple.clone(), "Conflicting instances of args and args_tuple")?;
 
         macro_rules! only_first {
             ($($a:ident),*) => {

--- a/src/meta_attrs/mod.rs
+++ b/src/meta_attrs/mod.rs
@@ -45,7 +45,7 @@ impl PassedValues {
 #[derive(Debug, Clone)]
 pub enum Imports {
     List(Vec<Ident>, Vec<Type>),
-    Tuple(Ident, Type)
+    Tuple(Ident, Box<Type>)
 }
 
 impl Default for Imports {

--- a/src/meta_attrs/mod.rs
+++ b/src/meta_attrs/mod.rs
@@ -8,9 +8,8 @@ pub(crate) use spanned_value::SpannedValue;
 
 use proc_macro2::TokenStream;
 use crate::compiler_error::{CompileError, SpanError};
-use syn::{Expr, Field, Ident, Lit, Meta, NestedMeta, parse::Parse, Path, Type, spanned::Spanned};
+use syn::{Expr, Ident, Lit, parse::Parse, Type, spanned::Spanned};
 use quote::ToTokens;
-use std::str::FromStr;
 use syn::export::TokenStream2;
 
 use self::parser::MetaList;

--- a/src/meta_attrs/mod.rs
+++ b/src/meta_attrs/mod.rs
@@ -124,3 +124,29 @@ fn convert_assert<K>(assert: &MetaList<K, Expr>) -> Result<Assert, CompileError>
         err.map(ToTokens::into_token_stream)
     ))
 }
+
+fn first_span_true(mut vals: impl Iterator<Item = impl Spanned>) -> SpannedValue<bool> {
+    if let Some(val) = vals.next() {
+        SpannedValue::new(
+            true,
+            val.span()
+        )
+    } else {
+        Default::default()
+    }
+}
+
+fn get_only_first<'a, S: Spanned>(list: impl Iterator<Item = &'a S>, msg: impl Into<String>) -> Result<Option<&'a S>, CompileError> {
+    let mut list = list.peekable();
+    let first = list.next();
+
+    if list.peek().is_none() {
+        Ok(first)
+    } else {
+        let span = list.map(Spanned::span).fold(Spanned::span(first.unwrap()), |x, y| x.join(y).unwrap());
+        Err(CompileError::SpanError(SpanError::new(
+            span,
+            msg
+        )))
+    }
+}

--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -32,7 +32,7 @@ parse_any!{
 
         // args type
         Import(MetaList<kw::import, ImportArg>),
-        ImportTuple(ImportArgTuple),
+        ImportTuple(Box<ImportArgTuple>),
         Assert(MetaList<kw::assert, Expr>),
         PreAssert(MetaList<kw::pre_assert, Expr>),
         Map(MetaFunc<kw::map>),

--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -121,10 +121,12 @@ pub struct ImportArgTuple {
 
 impl Parse for ImportArgTuple {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ident = input.parse()?;
         let content;
+        let parens = parenthesized!(content in input);
         Ok(ImportArgTuple {
-            ident: input.parse()?,
-            parens: parenthesized!(content in input),
+            ident,
+            parens,
             arg: content.parse()?
         })
     }

--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -9,9 +9,8 @@ use keywords as kw;
 pub(crate) mod parse_any;
 
 pub(crate) use meta_types::*;
-use proc_macro::TokenStream;
-use syn::parse::{Parse, ParseStream, Parser};
-use syn::{parenthesized, parse_macro_input, token, Field, Ident, Token, Lit, Path, Expr};
+use syn::parse::{Parse, ParseStream};
+use syn::{parenthesized, token, Ident, Token, Lit, Path, Expr};
 use syn::ExprClosure;
 use syn::punctuated::Punctuated;
 use proc_macro2::TokenStream as TokenStream2;

--- a/src/meta_attrs/parser/meta_types.rs
+++ b/src/meta_attrs/parser/meta_types.rs
@@ -44,10 +44,12 @@ pub struct MetaList<Keyword: Parse, ItemType: Parse> {
 
 impl<Keyword: Parse, ItemType: Parse> Parse for MetaList<Keyword, ItemType> {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ident = input.parse()?;
         let content;
+        let parens = parenthesized!(content in input);
         Ok(MetaList {
-            ident: input.parse()?,
-            parens: parenthesized!(content in input),
+            ident,
+            parens,
             fields: content.parse_terminated::<_, Token![,]>(ItemType::parse)?.into_iter().collect()
         })
     }

--- a/src/meta_attrs/parser/meta_types.rs
+++ b/src/meta_attrs/parser/meta_types.rs
@@ -1,6 +1,4 @@
 use super::*;
-use proc_macro2::Span;
-use syn::spanned::Spanned;
 use super::super::PassedValues;
 
 /// MetaExpr represents a key/expr pair

--- a/src/meta_attrs/parser/parse_any.rs
+++ b/src/meta_attrs/parser/parse_any.rs
@@ -17,7 +17,7 @@ macro_rules! parse_any {
 
         impl syn::parse::Parse for $enum {
             fn parse(input: ParseStream) -> syn::Result<Self> {
-                let x = input.parse().map(|path| Self::$variant1(path));
+                let x = input.parse().map(Self::$variant1);
                 $(
                     let x = x.or_else(|_: syn::Error|{
                             Ok(Self::$variantn(input.parse()?))

--- a/src/meta_attrs/parser/parsing_tests.rs
+++ b/src/meta_attrs/parser/parsing_tests.rs
@@ -29,17 +29,6 @@ macro_rules! parse_ty {
     }
 }
 
-macro_rules! parse_ty_print {
-    ($name:ident, $str:literal, $ty:ty) => {
-        #[test]
-        fn $name() {
-            let tokens: TokenStream2 = ($str).parse().unwrap();
-            let val: $ty = syn::parse2(tokens).unwrap();
-            dbg!(val);
-        }
-    }
-}
-
 macro_rules! parse_ty_fail {
     ($name:ident, $str:literal, $ty:ty) => {
         #[test]

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -108,7 +108,7 @@ impl TopLevelAttrs {
         let magic = get_only_first(&magics, "Cannot define multiple magic values")?;
 
         // TODO: this is basically get_only_first, but for incompatible attributes
-        if imports.len() > 0 && import_tuples.len() > 0 {
+        if !imports.is_empty() && !import_tuples.is_empty() {
             let mut spans = imports.iter()
                 .map(Spanned::span)
                 .chain(import_tuples.iter().map(Spanned::span));

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -1,8 +1,7 @@
 use super::*;
-use super::parser::{TopLevelAttr, MetaAttrList, BinreadAttribute, MetaList, MetaLit};
+use super::parser::{TopLevelAttr, MetaAttrList, MetaList, MetaLit};
 use syn::spanned::Spanned;
 use syn::parse::Parse;
-use proc_macro2::Span;
 use crate::CompileError;
 use quote::ToTokens;
 use super::parser::ImportArg;

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -68,7 +68,7 @@ impl TopLevelAttrs {
         Self::from_attrs(&input.attrs)
     }
 
-    pub fn from_attrs(attrs: &Vec<syn::Attribute>) -> Result<Self, CompileError> {
+    pub fn from_attrs(attrs: &[syn::Attribute]) -> Result<Self, CompileError> {
         let attrs: Vec<TopLevelAttr> =
             attrs
                 .iter()
@@ -183,7 +183,7 @@ fn convert_import<K: Parse>(import: Option<&&MetaList<K, ImportArg>>, import_tup
     }
 }
 
-fn get_only_first<'a, S: Spanned>(list: &'a Vec<S>, msg: &str) -> Result<Option<&'a S>, CompileError> {
+fn get_only_first<'a, S: Spanned>(list: &'a [S], msg: &str) -> Result<Option<&'a S>, CompileError> {
     if list.len() > 1 {
         let mut spans = list.iter().map(Spanned::span);
 
@@ -210,7 +210,7 @@ fn first_span_true<S: Spanned>(vals: Vec<S>) -> SpannedValue<bool> {
     }
 }
 
-fn join_spans_err<S1, S2>(s1: &Vec<S1>, s2: &Vec<S2>, msg: &str) -> Result<(), CompileError>
+fn join_spans_err<S1, S2>(s1: &[S1], s2: &[S2], msg: &str) -> Result<(), CompileError>
     where S1: Spanned,
           S2: Spanned,
 {

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -104,20 +104,7 @@ impl TopLevelAttrs {
 
         let magic = get_only_first(magics, "Cannot define multiple magic values")?;
 
-        // TODO: this is basically get_only_first, but for incompatible attributes
-        if imports.clone().next().is_some() && import_tuples.clone().next().is_some() {
-            let mut spans = imports
-                .map(Spanned::span)
-                .chain(import_tuples.map(Spanned::span));
-
-            let first = spans.next().unwrap();
-            let span = spans.fold(first, |x, y| x.join(y).unwrap());
-
-            return Err(CompileError::SpanError(SpanError::new(
-                span,
-                "Cannot mix import and import_tuple"
-            )));
-        }
+        check_mutually_exclusive(imports.clone(), import_tuples.clone(), "Cannot mix import and import_tuple")?;
 
         let import = get_only_first(imports, "Cannot define multiple sets of arguments")?;
         let import_tuple = get_only_first(import_tuples, "Cannot define multiple sets of tuple arguments")?;

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -94,7 +94,7 @@ impl TopLevelAttrs {
         let return_unexpected_errors = get_tla_type!(attrs.ReturnUnexpectedError);
 
         if return_all_errors.len() + return_unexpected_errors.len() > 1 {
-            join_spans_err(&bigs, &littles, "Cannot set more than one return type")?;
+            join_spans_err(&return_all_errors, &return_unexpected_errors, "Cannot set more than one return type")?;
         }
 
         let magics = get_tla_type!(attrs.Magic);

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -76,8 +76,7 @@ impl TopLevelAttrs {
                 .map(tlas_from_attribute)
                 .collect::<Result<Vec<TlaList>, CompileError>>()?
                 .into_iter()
-                .map(|x| x.0.into_iter())
-                .flatten()
+                .flat_map(|x| x.0.into_iter())
                 .collect();
 
         Self::from_top_level_attrs(attrs)

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -44,7 +44,6 @@ macro_rules! get_tla_type {
                     None
                 }
             })
-            .collect::<Vec<_>>()
     };
 }
 
@@ -86,15 +85,15 @@ impl TopLevelAttrs {
         let bigs = get_tla_type!(attrs.Big);
         let littles = get_tla_type!(attrs.Little);
 
-        if bigs.len() + littles.len() > 1 {
-            join_spans_err(&bigs, &littles, "Cannot set endianess more than once")?;
+        if bigs.clone().take(2).count() + littles.clone().take(2).count() > 1 {
+            return join_spans_err(bigs, littles, "Cannot set endianess more than once");
         }
 
         let return_all_errors = get_tla_type!(attrs.ReturnAllErrors);
         let return_unexpected_errors = get_tla_type!(attrs.ReturnUnexpectedError);
 
-        if return_all_errors.len() + return_unexpected_errors.len() > 1 {
-            join_spans_err(&return_all_errors, &return_unexpected_errors, "Cannot set more than one return type")?;
+        if return_all_errors.clone().take(2).count() + return_unexpected_errors.clone().take(2).count() > 1 {
+            return join_spans_err(return_all_errors, return_unexpected_errors, "Cannot set more than one return type");
         }
 
         let magics = get_tla_type!(attrs.Magic);
@@ -104,13 +103,13 @@ impl TopLevelAttrs {
         let pre_asserts = get_tla_type!(attrs.PreAssert);
         let map = get_tla_type!(attrs.Map);
 
-        let magic = get_only_first(&magics, "Cannot define multiple magic values")?;
+        let magic = get_only_first(magics, "Cannot define multiple magic values")?;
 
         // TODO: this is basically get_only_first, but for incompatible attributes
-        if !imports.is_empty() && !import_tuples.is_empty() {
-            let mut spans = imports.iter()
+        if imports.clone().next().is_some() && import_tuples.clone().next().is_some() {
+            let mut spans = imports
                 .map(Spanned::span)
-                .chain(import_tuples.iter().map(Spanned::span));
+                .chain(import_tuples.map(Spanned::span));
 
             let first = spans.next().unwrap();
             let span = spans.fold(first, |x, y| x.join(y).unwrap());
@@ -121,12 +120,12 @@ impl TopLevelAttrs {
             )));
         }
 
-        let import = get_only_first(&imports, "Cannot define multiple sets of arguments")?;
-        let import_tuple = get_only_first(&import_tuples, "Cannot define multiple sets of tuple arguments")?;
-        let map = get_only_first(&map, "Cannot define multiple mapping functions")?;
+        let import = get_only_first(imports, "Cannot define multiple sets of arguments")?;
+        let import_tuple = get_only_first(import_tuples, "Cannot define multiple sets of tuple arguments")?;
+        let map = get_only_first(map, "Cannot define multiple mapping functions")?;
 
         Ok(Self {
-            assert: asserts.into_iter().map(convert_assert).collect::<Result<_, _>>()?,
+            assert: asserts.map(convert_assert).collect::<Result<_, _>>()?,
             big: first_span_true(bigs),
             little: first_span_true(littles),
             magic: magic.map(magic_to_tokens),
@@ -134,13 +133,13 @@ impl TopLevelAttrs {
             import: convert_import(import, import_tuple).unwrap_or_default(),
             return_all_errors: first_span_true(return_all_errors),
             return_unexpected_error: first_span_true(return_unexpected_errors),
-            pre_assert: pre_asserts.into_iter().map(convert_assert).collect::<Result<_, _>>()?,
+            pre_assert: pre_asserts.map(convert_assert).collect::<Result<_, _>>()?,
             map: map.map(|x| x.to_token_stream()),
         })
     }
 }
 
-fn magic_to_type(magic: &&MetaLit<impl syn::parse::Parse>) -> MagicType {
+fn magic_to_type(magic: &MetaLit<impl syn::parse::Parse>) -> MagicType {
     let magic = &magic.lit;
     match magic {
         Lit::Str(_) => MagicType::Str,
@@ -154,7 +153,7 @@ fn magic_to_type(magic: &&MetaLit<impl syn::parse::Parse>) -> MagicType {
     }
 }
 
-fn magic_to_tokens(magic: &&MetaLit<impl syn::parse::Parse>) -> TokenStream {
+fn magic_to_tokens(magic: &MetaLit<impl syn::parse::Parse>) -> TokenStream {
     let magic = &magic.lit;
     if let Lit::Str(_) | Lit::ByteStr(_) = magic {
         quote::quote!{
@@ -165,9 +164,10 @@ fn magic_to_tokens(magic: &&MetaLit<impl syn::parse::Parse>) -> TokenStream {
     }
 }
 
-fn convert_import<K: Parse>(import: Option<&&MetaList<K, ImportArg>>, import_tuple: Option<impl AsRef<ImportArgTuple>>) -> Option<Imports> {
+fn convert_import<K: Parse>(import: Option<&MetaList<K, ImportArg>>, import_tuple: Option<impl AsRef<ImportArgTuple>>) -> Option<Imports> {
     if let Some(tuple) = import_tuple {
-        Some(Imports::Tuple(tuple.as_ref().arg.ident.clone(), tuple.as_ref().arg.ty.clone().into()))
+        let tuple = tuple.as_ref();
+        Some(Imports::Tuple(tuple.arg.ident.clone(), tuple.arg.ty.clone().into()))
     } else if let Some(list) = import {
         let (idents, tys): (Vec<_>, Vec<_>) =
             list.fields
@@ -182,41 +182,13 @@ fn convert_import<K: Parse>(import: Option<&&MetaList<K, ImportArg>>, import_tup
     }
 }
 
-fn get_only_first<'a, S: Spanned>(list: &'a [S], msg: &str) -> Result<Option<&'a S>, CompileError> {
-    if list.len() > 1 {
-        let mut spans = list.iter().map(Spanned::span);
-
-        let first = spans.next().unwrap();
-        let span = spans.fold(first, |x, y| x.join(y).unwrap());
-
-        return Err(CompileError::SpanError(SpanError::new(
-            span,
-            msg
-        )));
-    }
-    
-    Ok(list.get(0))
-}
-
-fn first_span_true<S: Spanned>(vals: Vec<S>) -> SpannedValue<bool> {
-    if let Some(val) = vals.get(0) {
-        SpannedValue::new(
-            true,
-            val.span()
-        )
-    } else {
-        Default::default()
-    }
-}
-
-fn join_spans_err<S1, S2>(s1: &[S1], s2: &[S2], msg: &str) -> Result<(), CompileError>
-    where S1: Spanned,
-          S2: Spanned,
+fn join_spans_err<'a, Iter1, Iter2, S1, S2>(s1: Iter1, s2: Iter2, msg: impl Into<String>) -> Result<TopLevelAttrs, CompileError>
+    where Iter1: Iterator<Item = &'a S1>,
+          Iter2: Iterator<Item = &'a S2>,
+          S1: Spanned + 'a,
+          S2: Spanned + 'a,
 {
-    let mut spans =
-        s1.iter().map(Spanned::span)
-            .chain(s2.iter().map(Spanned::span));
-
+    let mut spans = s1.map(Spanned::span).chain(s2.map(Spanned::span));
     let first = spans.next().unwrap();
     let span = spans.fold(first, |x, y| x.join(y).unwrap());
 

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -166,9 +166,9 @@ fn magic_to_tokens(magic: &&MetaLit<impl syn::parse::Parse>) -> TokenStream {
     }
 }
 
-fn convert_import<K: Parse>(import: Option<&&MetaList<K, ImportArg>>, import_tuple: Option<&&ImportArgTuple>) -> Option<Imports> {
+fn convert_import<K: Parse>(import: Option<&&MetaList<K, ImportArg>>, import_tuple: Option<impl AsRef<ImportArgTuple>>) -> Option<Imports> {
     if let Some(tuple) = import_tuple {
-        Some(Imports::Tuple(tuple.arg.ident.clone(), tuple.arg.ty.clone()))
+        Some(Imports::Tuple(tuple.as_ref().arg.ident.clone(), tuple.as_ref().arg.ty.clone().into()))
     } else if let Some(list) = import {
         let (idents, tys): (Vec<_>, Vec<_>) =
             list.fields

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,7 +1,0 @@
-use binread_derive::BinRead;
-
-#[derive(BinRead)]
-#[br(big)]
-struct Test {
-    foo: u32
-}


### PR DESCRIPTION
Since I had to pull binread into my tree to fix the field-level asserts, I ended up getting a bunch of warnings from rustc and clippy, so I went through and fixed them. Each kind of fix exists within a separate commit just in case you don’t want to include some of them.

Commit 9f7076d060e29f860db1875fe60a8ff0b29af0d3 is probably the most questionable change; see the commit message for more on that.

8d2758ac862a707756d764a17064e81dbc375718 is also a somewhat riskier change since it replaces all the Vec and slice-based interfaces with Iterator-based interfaces. All tests continue to pass, but it might have introduced some bugs not captured in the test suite. I didn’t profile this change, so I don’t know for sure that it is faster, but I think it should at least avoid some heap allocations that were happening before, and that’s usually good.