### PR TITLE
Implement automatic derive for unit-type enums

### DIFF
--- a/src/codegen/read_options.rs
+++ b/src/codegen/read_options.rs
@@ -239,9 +239,9 @@ fn merge_tlas(top_level: &TopLevelAttrs, enum_level: TopLevelAttrs) -> Result<To
 fn generate_struct(input: &DeriveInput, tla: &TopLevelAttrs, ds: &DataStruct) -> Result<TokenStream, CompileError> {
     let (field_attrs, (name, ty, struct_type))
         = (get_struct_field_attrs(&ds)?, get_struct_names_types(&ds));
-    
+
     let read_struct_body = generate_body(tla, &field_attrs, &name, ty)?;
-    
+
     let struct_name = input.ident.to_string();
     let struct_assertions = get_assertions(&tla.assert);
 
@@ -301,7 +301,7 @@ fn generate_body(
 
     let repeat_handle_error = iter::repeat(&handle_error);
     let repeat_handle_error2 = iter::repeat(&handle_error);
-    
+
     let maps = get_maps(&field_attrs);
     let names_after_ignores = ignore_names(&name, &field_attrs);
     let ty_after_ignores = ignore_types(&ty, &field_attrs);
@@ -310,7 +310,7 @@ fn generate_body(
         &field_attrs,
         quote!{}
     );
-    
+
     // Handle the actual conditions for if tags
     let (setup_possible_if, possible_if, possible_else, possible_some)
         = possible_if_else(&field_attrs, &name);
@@ -330,18 +330,18 @@ fn generate_body(
 
     Ok(quote!{
         let #arg_vars = #ARGS;
-        
+
         let #OPT = #top_level_option;
-        
+
         #magic_handler
 
         #(
             #save_position
             let #name_args = (#passed_args_closure).clone();
             let #name_options = #new_options;
-            
+
             #setup_possible_if
-            let #opt_mut #names_after_ignores: #ty_after_ignores = 
+            let #opt_mut #names_after_ignores: #ty_after_ignores =
                 #possible_if {
                     #seek_before
                     #skip_before
@@ -562,7 +562,7 @@ fn get_name_option_pairs_ident_expr(field_attrs: &FieldLevelAttrs, ident: &Ident
     } else {
         None
     };
-    
+
     let offset =
         field_attrs.offset
             .as_ref()
@@ -595,11 +595,11 @@ fn get_modified_options<'a, I: IntoIterator<Item = (IdentStr<'a>, TokenStream)>>
         quote!{
             &{
                 let mut temp = #OPT.clone();
-                
+
                 #(
                     temp.#ident = #expr;
                 )*
-                
+
                 temp
             }
         }
@@ -809,7 +809,7 @@ fn filter_by_ignore<'a, I>(field_attrs: &[FieldLevelAttrs], idents: I) -> Vec<To
 }
 
 fn possible_if_else(field_attrs: &[FieldLevelAttrs], idents: &[Ident]) -> (Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>, Vec<TokenStream>) {
-    let (cond_eval, if_stmt) = 
+    let (cond_eval, if_stmt) =
         field_attrs
             .iter()
             .zip(get_name_modified(idents, "cond_evaluated"))
@@ -938,7 +938,7 @@ fn generate_skips(field_attrs: &[FieldLevelAttrs]) -> Skips {
             }}
         }));
     }
-    
+
     Skips {
         seek_before,
         skip_before,
@@ -977,7 +977,7 @@ fn save_restore_position(field_attrs: &[FieldLevelAttrs]) -> (Vec<TokenStream>, 
                     quote!{
                         let #SAVED_POSITION = #SEEK_TRAIT::seek(#READER, #SEEK_FROM::Current(0))#handle_error?;
                     },
-                    quote!{ 
+                    quote!{
                         #SEEK_TRAIT::seek(#READER, #SEEK_FROM::Start(#SAVED_POSITION))#handle_error?;
                     }
                 )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ fn generate_derive(input: DeriveInput, code: codegen::GeneratedCode) -> TokenStr
             }
 
             fn after_parse<R: #READ_TRAIT + #SEEK_TRAIT> (&mut self, #READER: &mut R,
-                #OPT : &#OPTIONS, #ARGS : Self::Args) 
+                #OPT : &#OPTIONS, #ARGS : Self::Args)
                 -> #BIN_RESULT<()>
             {
                 #after_parse_impl
@@ -64,7 +64,7 @@ pub fn derive_binread_trait(input: TokenStream) -> TokenStream {
                     }
                 }
                 CompileError::Syn(syn_err) => syn_err.to_compile_error()
-                
+
             };
             generate_derive(input, codegen::GeneratedCode::new(
                 quote!(todo!()),
@@ -108,7 +108,7 @@ fn remove_field_attrs(fields: &mut syn::Fields) {
 #[proc_macro_attribute]
 pub fn derive_binread(_: TokenStream, input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
-    
+
     let derive: TokenStream2 = match codegen::generate(&input) {
         Ok(code) => {
             generate_derive(input.clone(), code)
@@ -123,7 +123,7 @@ pub fn derive_binread(_: TokenStream, input: TokenStream) -> TokenStream {
                     }
                 }
                 CompileError::Syn(syn_err) => syn_err.to_compile_error()
-                
+
             };
             generate_derive(input.clone(), codegen::GeneratedCode::new(
                 quote!(todo!()),

--- a/src/meta_attrs/field_level_attrs.rs
+++ b/src/meta_attrs/field_level_attrs.rs
@@ -30,10 +30,10 @@ pub(crate) struct FieldLevelAttrs {
     pub big: SpannedValue<bool>,
     pub is_big: Option<TokenStream>,
     pub is_little: Option<TokenStream>,
-    
+
     // assertions/error handling
     pub assert: Vec<Assert>,
-    
+
     // TODO: this
     pub magic: Option<Lit>,
     pub pad_before: Option<TokenStream>,
@@ -137,7 +137,7 @@ impl FieldLevelAttrs {
         } else {
             PassedArgs::List(args.unwrap_or_default())
         };
-        
+
         Ok(Self {
             little,
             big,
@@ -148,7 +148,7 @@ impl FieldLevelAttrs {
             restore_position,
             do_try,
             temp,
-            
+
             calc,
             count,
             offset,

--- a/src/meta_attrs/parser.rs
+++ b/src/meta_attrs/parser.rs
@@ -10,14 +10,14 @@ pub(crate) mod parse_any;
 
 pub(crate) use meta_types::*;
 use syn::parse::{Parse, ParseStream};
-use syn::{parenthesized, token, Ident, Token, Lit, Path, Expr};
+use syn::{parenthesized, token, Ident, Token, Type, Lit, Path, Expr};
 use syn::ExprClosure;
 use syn::punctuated::Punctuated;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
 
 // import, return_all_errors, return_unexpected_error, little, big, assert,
-// magic, pre_assert
+// magic, pre_assert, repr
 parse_any!{
     enum TopLevelAttr {
         // bool type
@@ -28,6 +28,9 @@ parse_any!{
 
         // lit assignment type
         Magic(MetaLit<kw::magic>),
+
+        // ty assignment type
+        Repr(Box<MetaType<kw::repr>>),
 
         // args type
         Import(MetaList<kw::import, ImportArg>),

--- a/src/meta_attrs/parser/keywords.rs
+++ b/src/meta_attrs/parser/keywords.rs
@@ -42,7 +42,7 @@ kws!{
     offset_after,     // offset(expr)
     /*if,*/     // if(expr)
     temp,
-    
+
     pad_before,   // pad_before(expr)
     pad_after,    // pad_after(expr)
     align_before, // align_before(expr)

--- a/src/meta_attrs/parser/keywords.rs
+++ b/src/meta_attrs/parser/keywords.rs
@@ -21,6 +21,7 @@ kws!{
     // top-level
     import,     // import(expr, ..)
     import_tuple, // import(expr)
+    repr,
     return_all_errors,
     return_unexpected_error,
 

--- a/src/meta_attrs/parser/parsing_tests.rs
+++ b/src/meta_attrs/parser/parsing_tests.rs
@@ -45,6 +45,8 @@ test_tla!(parse_magic, "magic = 3u8");
 test_tla!(parse_magic_paren, "magic(2u16)");
 test_tla!(parse_import, "import(x: u32, y: &[f32])");
 test_tla!(parse_import_tuple, "import_tuple(args: (u32))");
+test_tla!(parse_repr, "repr = u8");
+test_tla!(parse_repr_paren, "repr(i32)");
 
 test_fla!(fla_little, "little");
 test_fla!(fla_magic, "magic = b\"TEST\"");
@@ -71,6 +73,8 @@ parse_ty!(meta_byte_lit, "magic = b\"TEST\"", MetaLit<kw::magic>);
 parse_ty!(meta_str_lit, "magic = \"string\"", MetaLit<kw::magic>);
 parse_ty!(meta_func_closure, "map = |x| x + 1", MetaFunc<kw::map>);
 parse_ty!(meta_func_path, "map = ToString::to_string", MetaFunc<kw::map>);
+parse_ty!(meta_ty, "repr = u8", MetaType<kw::repr>);
 
 parse_ty_fail!(meta_lit_panic, "= 3u8", MetaLit<kw::magic>);
 parse_ty_fail!(meta_lit_panic2, "test = 3u8", MetaLit<kw::magic>);
+parse_ty_fail!(meta_ty_panic, "repr = 3u8", MetaType<kw::repr>);

--- a/src/meta_attrs/spanned_value.rs
+++ b/src/meta_attrs/spanned_value.rs
@@ -18,7 +18,7 @@ impl<T> SpannedValue<T> {
 
 impl<T> std::ops::Deref for SpannedValue<T> {
     type Target = T;
-    
+
     fn deref(&self) -> &Self::Target {
         &self.value
     }

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -13,6 +13,7 @@ pub struct TopLevelAttrs {
     //  Top-Only Attributes
     // ======================
     pub import: Imports, // Vec<Ident>, Vec<Type>
+    pub repr: Option<Type>,
     pub return_all_errors: SpannedValue<bool>,
     pub return_unexpected_error: SpannedValue<bool>,
 
@@ -102,6 +103,7 @@ impl TopLevelAttrs {
         let pre_asserts = get_tla_type!(attrs.PreAssert);
         let map = get_tla_type!(attrs.Map);
 
+        let repr = get_only_first(get_tla_type!(attrs.Repr), "Cannot define multiple repr values")?;
         let magic = get_only_first(magics, "Cannot define multiple magic values")?;
 
         check_mutually_exclusive(imports.clone(), import_tuples.clone(), "Cannot mix import and import_tuple")?;
@@ -117,6 +119,7 @@ impl TopLevelAttrs {
             magic: magic.map(magic_to_tokens),
             magic_type: magic.map(magic_to_type),
             import: convert_import(import, import_tuple).unwrap_or_default(),
+            repr: repr.map(|r| r.value.clone()),
             return_all_errors: first_span_true(return_all_errors),
             return_unexpected_error: first_span_true(return_unexpected_errors),
             pre_assert: pre_asserts.map(convert_assert).collect::<Result<_, _>>()?,

--- a/src/meta_attrs/top_level_attrs.rs
+++ b/src/meta_attrs/top_level_attrs.rs
@@ -22,7 +22,7 @@ pub struct TopLevelAttrs {
     // endian
     pub little: SpannedValue<bool>,
     pub big: SpannedValue<bool>,
-    
+
     // assertions/error handling
     pub assert: Vec<Assert>,
     pub magic: Option<TokenStream>,
@@ -58,7 +58,7 @@ impl TopLevelAttrs {
         Ok(self)
     }
 
-    pub fn from_derive_input(input: &syn::DeriveInput) -> Result<Self, CompileError> { 
+    pub fn from_derive_input(input: &syn::DeriveInput) -> Result<Self, CompileError> {
         Self::from_attrs(&input.attrs)
     }
 


### PR DESCRIPTION
This is a functioning, but incomplete, implementation of automatic derives for unit-type enums. It is incomplete, at least in part, because:

1. It does not limit the repr type to primitive types (and maybe this is OK, but probably it is not);
2. It does not support repr overrides on struct fields;
3. Discarding the invalid value instead of passing it back through the error is wrong.

I wanted to open for discussion on thoughts on these things, and anything else that looks weird in the PR.

For overriding the repr, normally stuff that can be overridden is passed through by `ReadOptions`, but since this feature requires giving a *type*, AFAIK it would not be possible to use the current API without some garbage like this:

```rust
enum EnumRepr { Original, U8, I8, U16, I16, U32, I32, U64, I64, U128, I128, Usize, Isize }

impl BinRead for #name {
  fn read_options<R: […]>(reader: R, options: &ReadOptions, _: Self::Args) -> […] {
    let v: #repr = match options.repr {
      EnumRepr::Original => #repr::read_options(reader, options, ())?,
      EnumRepr::U8 => u8::read_options(reader, options, ())?.try_into()?,
      EnumRepr::I8 => u8::read_options(reader, options, ())?.try_into()?,
      [… more boilerplate for each primitive type …]
  };

  #(#clauses else)* {
    Err(…NoVariantMatch…)
  }
}
```

I’m feeling exceptionally dumb tonight and can only think of things like:

1. Auto-implement `TryFrom` (tbh, feels like the compiler should be doing this already, and `num_trait::FromPrimitive` is just like some pre-generic, pre-TryFrom equivalent to this…), then have authors write `#[br(map = |value: i16| Enum::try_from(value).unwrap()]`[*]
2. Adding some new BinRead method with a signature like:

   ```rust
   fn parse_from<P, R>(reader: R, options: &ReadOptions, args: P::Args) -> Option<Self>
   where P: BinRead, R: Read + Seek, Self: Sized;
   ```

   which would then let the struct field generator just look to see if there’s a `repr` attribute, and if so, call `Enum::parse_from<#repr, _>(reader, options, #repr::args_default().expect("Must pass args, no args_default implemented"))`.

I am sure someone else (or me, later) can come up with something less dumb, since everything I just wrote feels like either a very specific or inappropriate solution to a more general problem. But, I wanted to at least get this out as a draft PR so that conversation can be started.

Also, sorry, there’s a whitespace-fixing commit attached to this because my editor kept fixing the whitespace errors and I decided to just fix them all at once so I could keep my editor fixing turned on to avoid introducing any new ones…

[*] I’m almost certainly going to open a new issue about adding a fallible `try_map`/`and_then`, since `map` can only panic right now, which is no good.